### PR TITLE
Remove page hidden field from filters form.

### DIFF
--- a/Admin/Admin.php
+++ b/Admin/Admin.php
@@ -171,6 +171,7 @@ abstract class Admin implements AdminInterface, DomainObjectInterface
      */
     protected $datagridValues = array(
         '_page'       => 1,
+        '_per_page'   => 10,
     );
 
     /**
@@ -382,6 +383,20 @@ abstract class Admin implements AdminInterface, DomainObjectInterface
     protected $securityInformation = array();
 
     /**
+     * Predefined per page options
+     *
+     * @var array
+     */
+    protected $perPageOptions = array(
+        10,
+        20,
+        50,
+        100,
+        150,
+        200,
+    );
+
+    /**
      * This method can be overwritten to tweak the form construction, by default the form
      * is built by reading the FieldDescription
      *
@@ -475,6 +490,8 @@ abstract class Admin implements AdminInterface, DomainObjectInterface
         $this->code                 = $code;
         $this->class                = $class;
         $this->baseControllerName   = $baseControllerName;
+        $this->predefinePerPageOptions();
+        $this->datagridValues['_per_page'] = $this->maxPerPage;
     }
 
     /**
@@ -626,6 +643,10 @@ abstract class Admin implements AdminInterface, DomainObjectInterface
                 $this->request->query->get('filter', array())
             );
 
+            if (!$this->determinedPerPageValue($parameters['_per_page'])) {
+                $parameters['_per_page'] = $this->maxPerPage;
+            }
+
             // always force the parent value
             if ($this->isChild() && $this->getParentAssociationMapping()) {
                 $parameters[$this->getParentAssociationMapping()] = array('value' => $this->request->get($this->getParent()->getIdParameter()));
@@ -648,8 +669,6 @@ abstract class Admin implements AdminInterface, DomainObjectInterface
 
         // initialize the datagrid
         $this->datagrid = $this->getDatagridBuilder()->getBaseDatagrid($this, $this->getFilterParameters());
-
-        $this->datagrid->getPager()->setMaxPerPage($this->maxPerPage);
 
         $mapper = new DatagridMapper($this->getDatagridBuilder(), $this->datagrid, $this);
 
@@ -2373,5 +2392,59 @@ abstract class Admin implements AdminInterface, DomainObjectInterface
     public function getLabelTranslatorStrategy()
     {
         return $this->labelTranslatorStrategy;
+    }
+
+    /**
+     * Set custom per page options
+     *
+     * @param $options
+     */
+    public function setPerPageOptions($options)
+    {
+        $this->perPageOptions = $options;
+    }
+
+    /**
+     * Returns predefined per page options
+     *
+     * @return array
+     */
+    public function getPerPageOptions()
+    {
+        return $this->perPageOptions;
+    }
+
+    /**
+     * Returns true if the per page value is allowed, false otherwise
+     *
+     * @param $per_page
+     * @return bool
+     */
+    public function determinedPerPageValue($per_page)
+    {
+        return in_array($per_page, $this->perPageOptions);
+    }
+
+    /**
+    * @param $per_page
+    * @return array
+    */
+    public function getPerPageParameters($per_page)
+    {
+        $values = $this->datagrid->getValues();
+
+        $values['_per_page'] = $per_page;
+
+        return array('filter' => $values);
+    }
+
+    /**
+     * Predefine per page options
+     */
+    protected function predefinePerPageOptions()
+    {
+        array_unshift($this->perPageOptions, $this->maxPerPage);
+        $this->perPageOptions = array_unique($this->perPageOptions);
+        sort($this->perPageOptions);
     }
 }

--- a/Datagrid/Datagrid.php
+++ b/Datagrid/Datagrid.php
@@ -102,6 +102,7 @@ class Datagrid implements DatagridInterface
         $this->formBuilder->add('_sort_by', 'hidden');
         $this->formBuilder->add('_sort_order', 'hidden');
         $this->formBuilder->add('_page', 'hidden');
+        $this->formBuilder->add('_per_page', 'hidden');
 
         $this->form = $this->formBuilder->getForm();
         $this->form->bind($this->values);
@@ -109,6 +110,7 @@ class Datagrid implements DatagridInterface
         $this->query->setSortBy(isset($this->values['_sort_by']) ? $this->values['_sort_by'] : null);
         $this->query->setSortOrder(isset($this->values['_sort_order']) ? $this->values['_sort_order'] : null);
 
+        $this->pager->setMaxPerPage(isset($this->values['_per_page']) ? $this->values['_per_page'] : 10);
         $this->pager->setPage(isset($this->values['_page']) ? $this->values['_page'] : 1);
         $this->pager->setQuery($this->query);
         $this->pager->init();

--- a/Resources/translations/SonataAdminBundle.en.xliff
+++ b/Resources/translations/SonataAdminBundle.en.xliff
@@ -270,6 +270,11 @@
               <source>label_filters</source>
               <target>Filters</target>
             </trans-unit>
+            <trans-unit id="label_per_page">
+              <source>label_per_page</source>
+              <target>Per page</target>
+            </trans-unit>
+
 
             <trans-unit id="delete_or">
               <source>delete_or</source>

--- a/Resources/views/CRUD/base_list.html.twig
+++ b/Resources/views/CRUD/base_list.html.twig
@@ -105,6 +105,19 @@ file that was distributed with this source code.
                                       {% endif %}
 
                                   </ul>
+                                  <ul>
+                                      <li>
+                                          {% trans from 'SonataAdminBundle' %}label_per_page{% endtrans %}
+                                          <select onchange="window.top.location.href=this.options[this.selectedIndex].value">
+                                              <option value="" selected="selected">{{ admin.datagrid.pager.maxperpage }}</option>
+                                              {% for per_page in admin.getperpageoptions %}
+                                                  {% if per_page != admin.datagrid.pager.maxperpage %}
+                                                      <option value="{{ admin.generateUrl('list', admin.getperpageparameters(per_page)) }}">{{ per_page }}</option>
+                                                  {% endif %}
+                                              {% endfor %}
+                                          </select>
+                                      </li>
+                                </ul>
                                 </div>
 
                             </td>


### PR DESCRIPTION
The problem when you is on page more than 1 (2,3,4...) and apply filter.
For example, If you on 2nd page, apply filter and result of this filter return 1 record, you still stay on 2nd page and Datagrid result will be - "No Result". You will not see the search results.
