### PR TITLE
Remove page hidden field from filters form.

### DIFF
--- a/Datagrid/Datagrid.php
+++ b/Datagrid/Datagrid.php
@@ -101,7 +101,6 @@ class Datagrid implements DatagridInterface
 
         $this->formBuilder->add('_sort_by', 'hidden');
         $this->formBuilder->add('_sort_order', 'hidden');
-        $this->formBuilder->add('_page', 'hidden');
 
         $this->form = $this->formBuilder->getForm();
         $this->form->bind($this->values);


### PR DESCRIPTION
The problem when you is on page more than 1 (2,3,4...) and apply filter.
For example, If you on 2nd page, apply filter and result of this filter return 1 record, you still stay on 2nd page and Datagrid result will be - "No Result". You will not see the search results.
